### PR TITLE
add OpaquePointer conversion

### DIFF
--- a/Sources/IperfSwift/IperfRunner.swift
+++ b/Sources/IperfSwift/IperfRunner.swift
@@ -95,7 +95,7 @@ public class IperfRunner {
             return
         }
         while true {
-            let intervalResultsP: UnsafeMutablePointer<iperf_interval_results>? = extract_iperf_interval_results(stream)
+            let intervalResultsP: UnsafeMutablePointer<iperf_interval_results>? = extract_iperf_interval_results(OpaquePointer(stream))
             if let intervalResults = intervalResultsP?.pointee {
                 result.streams.append(IperfStreamIntervalResult(intervalResults))
             }


### PR DESCRIPTION
Fixes compilation error with recent xCode version by type casting to `OpaquePointer`